### PR TITLE
Fix bug with missing duration when playing urls/local files

### DIFF
--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -605,8 +605,12 @@ def mpd_wait_for_play(client):
             # Here we check if duration is in the track_info and use it if we can
             # Storing duration info in "time" is deprecated, as per the mpd spec,
             # however some servers (namely mopidy) still do this. Bad mopidy, bad.
+            # Use values from the status rather than the song, as duration is
+            # missing when using mpd to play urls or local files
             song_duration = float(
-                song["duration"] if "duration" in song else song["time"]
+                status["duration"]
+                if "duration" in status
+                else status[time].split(":")[-1]
             )
             title = song["title"]
             elapsed = float(status["elapsed"])
@@ -706,8 +710,12 @@ def mpd_watch_track(client, session, config):
             # Here we check if duration is in the track_info and use it if we can
             # Storing duration info in "time" is deprecated, as per the mpd spec,
             # however some servers (namely mopidy) still do this. Bad mopidy, bad.
+            # Use values from the status rather than the song, as duration is
+            # missing when using mpd to play urls or local files
             song_duration = float(
-                song["duration"] if "duration" in song else song["time"]
+                status["duration"]
+                if "duration" in status
+                else status["time"].split(":")[-1]
             )
 
             title = extract_single(song, "title")

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -610,7 +610,7 @@ def mpd_wait_for_play(client):
             song_duration = float(
                 status["duration"]
                 if "duration" in status
-                else status[time].split(":")[-1]
+                else status["time"].split(":")[-1]
             )
             title = song["title"]
             elapsed = float(status["elapsed"])


### PR DESCRIPTION
When playing urls or local files, a duration value isn't returned by python-mpd2.currentsong(), leading to keyerrors. Fix this by taking it from the player status instead.

The duration provided is the same in both the song and status, and as for time, there is a small difference in that it's stored as "current:total". However, I've only had a chance to test using mpd, so there could be some issues regarding mopidy I haven't found.