### PR TITLE
Allow scrobbling tracks outside MPD library if duration non-zero

### DIFF
--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -585,7 +585,9 @@ def print_song_info(client):
 
     # Storing duration info in "time" is deprecated, as per the mpd spec,
     # however some servers (namely mopidy) still do this. Bad mopidy, bad.
-    song_duration = float(song["duration"] if "duration" in status else song["time"])
+    song_duration = float(
+        status["duration"] if "duration" in status else status["time"].split(":")[-1]
+    )
 
     title = extract_single(song, "title")
 
@@ -626,7 +628,7 @@ def mpd_wait_for_play(client):
         state = status["state"]
 
         in_suitable_state = state == "play"
-        appropriate_track = is_track_scrobbleable(song)
+        appropriate_track = is_track_scrobbleable(song, status)
 
         # Prevents us from printing song info if we're not switching tracks
         if in_suitable_state and appropriate_track:
@@ -650,7 +652,7 @@ def mpd_wait_for_play(client):
             state = status["state"]
 
             in_suitable_state = state == "play"
-            appropriate_track = is_track_scrobbleable(song)
+            appropriate_track = is_track_scrobbleable(song, status)
 
             logger.info("Received state: {}".format(state))
 
@@ -664,29 +666,31 @@ def mpd_wait_for_play(client):
     return True
 
 
-def is_track_scrobbleable(track_info):
+def is_track_scrobbleable(song, status):
     """
     Returns true if a track is scrobbleable, e.g. if a track contains the required amount of fields for Last.FM's API
 
-    :param track_info: The track_info (generally returned from a currentsong API call)
+    :param song: The info on the track taken from client.currentsong()
+    :param status: The info on the track taken from client.status()
 
-    :type track_info: dict
+    :type song: dict
+    :type status: dict
     :rtype: bool
     """
 
-    def check_field(field, warn=False):
-        if field not in track_info:
+    def check_field(field, source, warn=False):
+        if field not in source:
             message = "Track is not scrobbleable as it has no {} field!".format(field)
             logger.warn(message) if warn else logger.debug(message)
             return False
         return True
 
     # If any of the following are False we are not scrobbleable.
-    scrobbleable = check_field("artist")
-    scrobbleable &= check_field("title")
+    scrobbleable = check_field("artist", song)
+    scrobbleable &= check_field("title", song)
     # We're doing a 'time' check here for mopidy, which uses it: a deprecated call to mpd
-    scrobbleable &= check_field("duration") or check_field("time")
-    scrobbleable &= check_field("album")
+    scrobbleable &= check_field("duration", status) or check_field("time", status)
+    scrobbleable &= check_field("album", song)
 
     return scrobbleable
 

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -668,7 +668,7 @@ def mpd_wait_for_play(client):
 
 def is_track_scrobbleable(song, status):
     """
-    Returns true if a track is scrobbleable, e.g. if a track contains the required amount of fields for Last.FM's API
+    Returns true if a track is scrobbleable, e.g. if a track contains the required amount of fields for Last.FM's API and track valid e.g. duration non-zero
 
     :param song: The info on the track taken from client.currentsong()
     :param status: The info on the track taken from client.status()
@@ -691,6 +691,15 @@ def is_track_scrobbleable(song, status):
     # We're doing a 'time' check here for mopidy, which uses it: a deprecated call to mpd
     scrobbleable &= check_field("duration", status) or check_field("time", status)
     scrobbleable &= check_field("album", song)
+
+    # If all fields present, check that song duration is not zero (would cause div by zero errors)
+    if scrobbleable:
+        song_duration = float(
+            status["duration"]
+            if "duration" in status
+            else status["time"].split(":")[-1]
+        )
+        scrobbleable &= song_duration > 0
 
     return scrobbleable
 


### PR DESCRIPTION
Adapt `is_track_scrobbleable` to allow scrobbling of tracks where the required `duration`/`time` fields are only stored in the `status` dictionary and not the `currentsong` dictionary.

Also, if required fields are present, check tracks to ensure they have a non-zero length. If not checked for, this can lead to division by zero errors when calculating percentages. This isn't a major issue as internet radio stations (which have a `time` field of "some value:0") will generally not have an album, track or artist field anyway, but prevents an outright crash of yams if a track which has a length of zero for some reason is played.

Scrobbling tracks outside of the MPD library will still cause some errors when disconnected from the network as they aren't stored with all the required fields, even though they're present, but I'm working on fixing that.