### PR TITLE
Send the "albumartist" tag if it's available

### DIFF
--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -343,6 +343,8 @@ def make_scrobble(track_info, status, api_secret=None, **other):
         scrobble["album"] = extract_single(track_info, "album")
     if "track" in track_info:
         scrobble["trackNumber"] = extract_single(track_info, "track")
+    if "albumartist" in track_info:
+        scrobble["albumArtist"] = extract_single(track_info, "albumartist")
     # Check for duration/time in status rather than track_info as they won't be present for tracks not
     # present in the mpd database (ie. streamed tracks)
     if "duration" in status:
@@ -415,6 +417,8 @@ def scrobble_tracks(tracks, url, api_key, api_secret, session_key):
                 tracks[i], "trackNumber"
             )
 
+        if "albumArtist" in tracks[i]:
+            parameters["albumArtist[{}]".format(i)] = extract_single(tracks[i], "albumArtist")
         if "duration" in tracks[i]:
             parameters["duration[{}]".format(i)] = extract_single(tracks[i], "duration")
 


### PR DESCRIPTION
When Last.FM receives an Album Artist tag, it merges the corresponding album in your library on a single entry.

This is very helpful if someone is listening to soundtracks, compilation albums, or simply albums that have a wide variety of
featured artists, given that some databases, like MusicBrainz's for instance, add the aforementioned features in the artist tag.

What this minor patch tries to achieve is to send the albumartist tag with the scrobble request if it can be found, both for cached scrobbles and regular scrobbles. This way, for example, an album composed by various artists, and with a "Various Artists" albumartist tag will only appear once in your album library, as opposed to the old behavior where it would appear several times: once per artist that was involved in the making of such album.

This is somewhat related to #12, but upon reading it again, I'm not exactly sure if what bndlfm wanted was scrobbling albums by albumartist, or rather use the albumartist instead of the artist if it's set to get rid of the "feat. X" altogether, which wouldn't exactly play nice with "Various Artists" albums in my opinion.