### PR TITLE
Move metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "YAMScrobbler"
+version = "0.7.3"
+description = "Yet Another MPD Scrobbler (for Last.FM!)"
+readme = "README.md"
+license = { text = "GPL-3.0" }
+
+
+authors = [
+        {name = "Derin Yarsuvat", email = "derin@ml1.net"},
+]
+
+dependencies = [
+             "python-mpd2>=1.0.0",
+             "PyYAML>=5.1",
+             "requests>=2.21.0",
+             "psutil>=5.6.3",
+             "importlib-metadata",
+]
+
+[project.urls]
+repository = "https://github.com/berulacks/yams.git"
+
+[project.scripts]
+yams = "yams.__main__:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,4 @@
 # from distutils.core import setup
 from setuptools import setup
-from yams import VERSION
 
-
-def readme():
-    with open("README.md", encoding="utf-8") as f:
-        return f.read()
-
-
-setup(
-    # Application name:
-    name="YAMScrobbler",
-    # Version number (initial):
-    version=VERSION,
-    # Application author details:
-    author="Derin Yarsuvat",
-    author_email="derin@ml1.net",
-    license="GPLv3",
-    # Packages
-    packages=["yams"],
-    package_data={},
-    # Include additional files into the package
-    include_package_data=False,
-    # Details
-    url="https://github.com/berulacks/yams",
-    download_url="https://github.com/Berulacks/yams/releases/download/{0}/yams-{0}-py3-none-any.whl".format(
-        VERSION
-    ),
-    #
-    # license="LICENSE.txt",
-    description="Yet Another MPD Scrobbler (for Last.FM!)",
-    long_description=readme(),
-    long_description_content_type="text/markdown",
-    entry_points={"console_scripts": ["yams = yams.__main__:main"]},
-    # Dependent packages (distributions)
-    install_requires=[
-        "python-mpd2>=1.0.0",
-        "PyYAML>=5.1",
-        "requests>=2.21.0",
-        "psutil>=5.6.3",
-    ],
-    python_requires=">=3",
-    zip_safe=False,
-)
+setup()

--- a/yams/__init__.py
+++ b/yams/__init__.py
@@ -1,7 +1,5 @@
 import yams
 
-VERSION = "0.7.3"
-
 
 def __init__():
     pass

--- a/yams/configure.py
+++ b/yams/configure.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
 import argparse
 import os
-import yaml
-import signal
 import logging
+from pathlib import Path
+import signal
 import subprocess
-import psutil
-from yams import VERSION
 from sys import exit
+
+import psutil
+import yaml
 
 HOME = str(Path.home())
 LOGGING_ENABLED = False

--- a/yams/configure.py
+++ b/yams/configure.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import importlib.metadata
 import logging
 from pathlib import Path
 import signal
@@ -240,7 +241,7 @@ def process_cli_args():
     parser = argparse.ArgumentParser(
         prog="YAMS",
         description="Yet Another Mpd Scrobbler, v{}. Configuration directories are either ~/.config/yams, ~/.yams, or your current working directory. Create one of these paths if need be.".format(
-            VERSION
+            importlib.metadata.version("YAMScrobbler")
         ),
     )
     parser.add_argument(

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 import logging
+import importlib.metadata
 from pathlib import Path
 import select
 from sys import exit
@@ -1048,7 +1049,7 @@ def cli_run():
 
     session = ""
     config = configure()
-    logger.info("Starting up YAMS v{}".format(yams.VERSION))
+    logger.info("Starting up YAMS v{}".format(importlib.metadata.version("YAMScrobbler")))
 
     session_file = config["session_file"]
     base_url = config["base_url"]

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 
-import requests, hashlib
+import hashlib
+import os
+import logging
+from pathlib import Path
+import select
+from sys import exit
+import time
 import xml.etree.ElementTree as ET
+
+import requests
 from mpd import MPDClient
 from mpd.base import ConnectionError
-import select
-from pathlib import Path
-import time
-import logging
 import yaml
-import os
-from sys import exit
 
 from yams.configure import configure, remove_log_stream_of_type
 import yams


### PR DESCRIPTION
- Move metadate to pyproject.toml
- Extract version from importlib.
  Retrieving metadata from importlib allows to
  store in one central place. Can be further used
  to set version from git with setuptools-scm