### PR TITLE
Refactor file handling to use platformdirs for config, state files etc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "YAMScrobbler"
+version = "0.7.3"
+description = "Yet Another MPD Scrobbler (for Last.FM!)"
+readme = "README.md"
+license = { text = "GPL-3.0" }
+
+
+authors = [
+        {name = "Derin Yarsuvat", email = "derin@ml1.net"},
+]
+
+dependencies = [
+             "python-mpd2>=1.0.0",
+             "PyYAML>=5.1",
+             "requests>=2.21.0",
+             "psutil>=5.6.3",
+             "importlib-metadata",
+]
+
+[project.urls]
+repository = "https://github.com/berulacks/yams.git"
+
+[project.scripts]
+yams = "yams.__main__:main"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
              "requests>=2.21.0",
              "psutil>=5.6.3",
              "importlib-metadata",
+             "platformdirs",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -1,45 +1,4 @@
 # from distutils.core import setup
 from setuptools import setup
-from yams import VERSION
 
-
-def readme():
-    with open("README.md", encoding="utf-8") as f:
-        return f.read()
-
-
-setup(
-    # Application name:
-    name="YAMScrobbler",
-    # Version number (initial):
-    version=VERSION,
-    # Application author details:
-    author="Derin Yarsuvat",
-    author_email="derin@ml1.net",
-    license="GPLv3",
-    # Packages
-    packages=["yams"],
-    package_data={},
-    # Include additional files into the package
-    include_package_data=False,
-    # Details
-    url="https://github.com/berulacks/yams",
-    download_url="https://github.com/Berulacks/yams/releases/download/{0}/yams-{0}-py3-none-any.whl".format(
-        VERSION
-    ),
-    #
-    # license="LICENSE.txt",
-    description="Yet Another MPD Scrobbler (for Last.FM!)",
-    long_description=readme(),
-    long_description_content_type="text/markdown",
-    entry_points={"console_scripts": ["yams = yams.__main__:main"]},
-    # Dependent packages (distributions)
-    install_requires=[
-        "python-mpd2>=1.0.0",
-        "PyYAML>=5.1",
-        "requests>=2.21.0",
-        "psutil>=5.6.3",
-    ],
-    python_requires=">=3",
-    zip_safe=False,
-)
+setup()

--- a/yams/__init__.py
+++ b/yams/__init__.py
@@ -1,7 +1,5 @@
 import yams
 
-VERSION = "0.7.3"
-
 
 def __init__():
     pass

--- a/yams/configure.py
+++ b/yams/configure.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 
-from pathlib import Path
 import argparse
 import os
-import yaml
-import signal
 import logging
+from pathlib import Path
+import signal
 import subprocess
-import psutil
-from yams import VERSION
 from sys import exit
+
+import psutil
+import yaml
 
 HOME = str(Path.home())
 LOGGING_ENABLED = False

--- a/yams/configure.py
+++ b/yams/configure.py
@@ -9,6 +9,7 @@ import signal
 import subprocess
 from sys import exit
 
+import platformdirs
 import psutil
 import yaml
 
@@ -16,14 +17,14 @@ HOME = str(Path.home())
 LOGGING_ENABLED = False
 
 PROGRAM_HOMES = [
-    "{}/.config/yams".format(HOME),
+    platformdirs.user_config_dir(appname="yams"),
     "{}/.yams".format(HOME),
     "./.yams",
     ".",
     HOME,
 ]
 
-CREATE_IF_NOT_EXISTS_HOME = "{}/.config/yams".format(HOME)
+CREATE_IF_NOT_EXISTS_HOME = platformdirs.user_config_dir(appname="yams")
 
 CONFIG_FILE = "yams.yml"
 LOG_FILE_NAME = "yams.log"
@@ -80,7 +81,8 @@ def bootstrap_config():
 
     default_config = DEFAULTS
 
-    default_config["session_file"] = str(Path(home, DEFAULT_SESSION_FILENAME))
+    default_config["session_file"] = str(Path(platformdirs.user_state_dir(
+        appname="yams"), DEFAULT_SESSION_FILENAME))
 
     # Lets recognize environment variables by the user
     if "MPD_HOST" in os.environ:
@@ -417,14 +419,19 @@ def configure():
     setup_logger(True, False, log_level)
     home = get_home_dir()
     config_path = str(Path(home, CONFIG_FILE))
+    app_dirs = platformdirs.PlatformDirs("yams")
 
     # 1 Defaults:
     config = DEFAULTS
     # 1.2 Home dependent defaults:
-    config["session_file"] = str(Path(home, DEFAULT_SESSION_FILENAME))
-    config["log_file"] = str(Path(home, LOG_FILE_NAME))
-    config["pid_file"] = str(Path(home, DEFAULT_PID_FILENAME))
-    config["cache_file"] = str(Path(home, DEFAULT_CACHE_FILENAME))
+    config["session_file"] = str(Path(app_dirs.user_state_dir,
+                                      DEFAULT_SESSION_FILENAME))
+    config["log_file"] = str(Path(app_dirs.user_state_dir,
+                                  LOG_FILE_NAME))
+    config["pid_file"] = str(Path(platformdirs.user_runtime_dir(),
+                             DEFAULT_PID_FILENAME))
+    config["cache_file"] = str(Path(app_dirs.user_cache_dir,
+                                    DEFAULT_CACHE_FILENAME))
     # 2 Environment variables
     if "MPD_HOST" in os.environ:
         config["mpd_host"] = os.environ["MPD_HOST"]

--- a/yams/configure.py
+++ b/yams/configure.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import importlib.metadata
 import logging
 from pathlib import Path
 import signal
@@ -240,7 +241,7 @@ def process_cli_args():
     parser = argparse.ArgumentParser(
         prog="YAMS",
         description="Yet Another Mpd Scrobbler, v{}. Configuration directories are either ~/.config/yams, ~/.yams, or your current working directory. Create one of these paths if need be.".format(
-            VERSION
+            importlib.metadata.version("YAMScrobbler")
         ),
     )
     parser.add_argument(

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 import logging
+import importlib.metadata
 from pathlib import Path
 import select
 from sys import exit
@@ -1048,7 +1049,7 @@ def cli_run():
 
     session = ""
     config = configure()
-    logger.info("Starting up YAMS v{}".format(yams.VERSION))
+    logger.info("Starting up YAMS v{}".format(importlib.metadata.version("YAMScrobbler")))
 
     session_file = config["session_file"]
     base_url = config["base_url"]

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -5,6 +5,7 @@ import os
 import logging
 import importlib.metadata
 from pathlib import Path
+import platformdirs
 import select
 from sys import exit
 import time
@@ -15,8 +16,7 @@ from mpd import MPDClient
 from mpd.base import ConnectionError
 import yaml
 
-from yams.configure import configure, remove_log_stream_of_type
-import yams
+from yams.configure import configure, remove_log_stream_of_type,  DEFAULT_CACHE_FILENAME
 
 MAX_TRACKS_PER_SCROBBLE = 50
 SCROBBLE_RETRY_INTERVAL = 10
@@ -24,7 +24,8 @@ SCROBBLE_DISK_SAVE_INTERVAL = 1200
 
 logger = logging.getLogger("yams")
 
-SCROBBLES = str(Path(Path.home(), ".config/yams/scrobbles.cache"))
+SCROBBLES = str(Path(platformdirs.user_cache_dir(appname="yams"),
+                     DEFAULT_CACHE_FILENAME))
 
 
 def save_failed_scrobbles_to_disk(path, scrobbles):

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
 
-import requests, hashlib
+import hashlib
+import os
+import logging
+from pathlib import Path
+import select
+from sys import exit
+import time
 import xml.etree.ElementTree as ET
+
+import requests
 from mpd import MPDClient
 from mpd.base import ConnectionError
-import select
-from pathlib import Path
-import time
-import logging
 import yaml
-import os
-from sys import exit
 
 from yams.configure import configure, remove_log_stream_of_type
 import yams

--- a/yams/scrobble.py
+++ b/yams/scrobble.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import atexit
 import hashlib
 import os
 import logging
@@ -996,6 +997,11 @@ def save_pid(file_path, pid=None):
         pid_file.writelines(str(pid) + "\n")
         logger.info("Wrote PID to file: {}".format(file_path))
 
+    atexit.register(rm_pid_atexit, Path(file_path))
+
+def rm_pid_atexit(pid_file_path):
+    "Delete pid file atexit handler"
+    pid_file_path.unlink()
 
 def fork(config):
     """


### PR DESCRIPTION
Instead of hard coding the config directory use platformdirs to find
the configuration directory. The benefit is that if the user has
changed XDG_CONFIG_HOME to a different directory the program still
works.
The side effect is that the program is more portable now.

Apply this also to the session file, the log file and the pid file to
move them to their appropriate directories. Fixes #17.

Requires regeneration of config file as these are stored in the
configuration file.

Includes #21.